### PR TITLE
nil checks

### DIFF
--- a/lib/mp3info/extension_modules.rb
+++ b/lib/mp3info/extension_modules.rb
@@ -23,7 +23,7 @@ class Mp3Info
       alias getbyte []
     else
       def getbyte(i)
-        self[i].ord
+        self[i].ord unless self[i].nil?
       end
     end
   end

--- a/lib/mp3info/id3v2.rb
+++ b/lib/mp3info/id3v2.rb
@@ -344,7 +344,7 @@ class ID3v2 < DelegateClass(Hash)
 	  end
 	end
         # remove padding zeros for textual tags
-        out.sub!(/\0*$/, '')
+        out.sub!(/\0*$/, '') unless out.nil?
         return out
       else
         return raw_value


### PR DESCRIPTION
As I was running using mp3info to publish my mp3 collection to a database, I hit a couple of odd nil problems.  The error in both cases was roughly "method ord is not defined for nil".  This pull request shows the changes I made to get past them and complete my work.  I haven't looked deeply at the cause and really consider these changes kludges.

Thanks for the library and I hope this patch gives some hints as to what I ran into.
