### PR TITLE
convert to utf-16 little endian (instead of big) for more compatibility

### DIFF
--- a/lib/mp3info/extension_modules.rb
+++ b/lib/mp3info/extension_modules.rb
@@ -49,7 +49,7 @@ class Mp3Info
         ruby_18_encode(from, to, value)
       else
         if to == "utf-16"
-          ("\uFEFF" +  value).encode("UTF-16BE")
+          ("\uFEFF" +  value).encode("UTF-16LE") # Chab 01.apr.2012 : moved from big to little endian for more compatibility (Windows Media Player, older Quicktime..)
         else
           value.encode(to)
         end

--- a/test/test_ruby-mp3info.rb
+++ b/test/test_ruby-mp3info.rb
@@ -441,6 +441,12 @@ class Mp3InfoTest < Test::Unit::TestCase
     assert(Mp3Info.hastag2?(io))
   end
 
+  def test_convert_to_utf16_little_endian
+    s = Mp3Info::EncodingHelper.convert_to("track's title €éàïôù", "utf-8", "utf-16")
+    expected = "ff fe 74 00 72 00 61 00 63 00 6b 00 27 00 73 00 20 00 74 00 69 00 74 00 6c 00 65 00 20 00 ac 20 e9 00 e0 00 ef 00 f4 00 f9 00"
+    assert_equal(expected, s.bytes.map{|b| b.to_s(16).rjust(2,"0")}.to_a.join(" "))
+  end
+
   def compute_audio_content_mp3_digest(mp3)
     pos, size = mp3.audio_content
     data = File.open(mp3.filename) do |f|


### PR DESCRIPTION
utf-16 "Little Endian" is to be more compatible than than "Big Endian" on Windows Media Player & older Quicktime.

Big Endian (as used in ruby-mp3info 0.7) is acting weird on some "older" players. Repro:
- encode TIT2 'hello€' in an mp3 id3s using gem 0.7.
- open it on OS X Snow Leopard's quicktime, and view infos (cmd+i), it shows chinese chars (as a screenshot submitted last week in "issues")
- open it on an older Windows Media Player (i did on a old Vista's standard WMP) : it can't even play the audio.

3 tested softwares encoding in utf-16 (iTunes, WMP & "id3 editor") encodes id3 in little endian. That confirmed the change. This is fixing the issue for us, hope it will for others!

Many thanks for this great lib, 
Chab
