### PR TITLE
Do not try to recover from an iconv failed call.

### DIFF
--- a/lib/mp3info/extension_modules.rb
+++ b/lib/mp3info/extension_modules.rb
@@ -65,11 +65,7 @@ class Mp3Info
     end
 
     def self.ruby_18_encode(from, to, value)
-      begin
-        Iconv.iconv(to, from, value).first
-      rescue Iconv::Failure
-        value
-      end
+      Iconv.iconv(to, from, value).first
     end
 
     def self.decode_utf16(out)


### PR DESCRIPTION
This is important as in some cases you might not have the extension
available, and then it's better to throw an error than providing a
wrongly-encoding string.
