### PR TITLE
Ruby 1.8 compatibility fix

### DIFF
--- a/lib/mp3info/id3v2.rb
+++ b/lib/mp3info/id3v2.rb
@@ -593,9 +593,8 @@ class ID3v2 < DelegateClass(Hash)
   
   ### this is especially useful for printing out APIC data because
   ### only the header of the APIC tag is of interest
-  ### The result also shows some bytes escaped for cleaner display
   def pretty_header(str, chars=128)
-    "#{str.unpack("a#{chars}").first}<<<...snip...>>>".force_encoding('BINARY').inspect[1..-2]
+    "#{str.unpack("a#{chars}").first}<<<...snip...>>>".inspect[1..-2]
   end
 
 


### PR DESCRIPTION
remove force_encoding method which was getting called during tag2.inspect
Important: ensures Ruby 1.8 can use the inspect method on the tag2 hash.
The other option is drop support for 1.8
