### PR TITLE
add missing fixtures.yml to gem

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -6,3 +6,4 @@ lib/mp3info.rb
 lib/mp3info/extension_modules.rb
 lib/mp3info/id3v2.rb
 test/test_ruby-mp3info.rb
+test/fixtures.yml


### PR DESCRIPTION
Please add missing fixtures.yml into Gem. Debian runs the test/ on package build time.
