### PR TITLE
Add a Travis CI build badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 * http://github.com/moumar/ruby-mp3info
 
+[![Build Status](https://travis-ci.org/moumar/ruby-mp3info.png?branch=master)](https://travis-ci.org/moumar/ruby-mp3info.png?branch=master)
+
 ## Description
 
 ruby-mp3info read low-level informations and manipulate tags on mp3 files.


### PR DESCRIPTION
This just adds a Travis CI badge to the top of the README. It's nice to be able to click through to the project on Travis without having to search.
