### PR TITLE
Relax testing for numeric genres in id3v2 tags

### DIFF
--- a/lib/mp3info.rb
+++ b/lib/mp3info.rb
@@ -274,9 +274,11 @@ class Mp3Info
           if %w{year tracknum}.include?(key)
             @tag[key] = tag_value.to_i
           end
-          # this is a special case with id3v2.2, which uses
+          # this is a special case with id3v2.2-3, which uses
           # old fashionned id3v1 genres
-          if tag2_name == "TCO" && tag_value =~ /^\((\d+)\)$/
+	  # also id3v2.4 ought not to use the old fashioned genres but examples exist where it does
+          if ( ((tag2_name == "TCO") || (tag2_name == "TCON")) && tag_value =~ /^\((\d+)\)$/) ||
+		(tag2_name == "TCON" && tag_value =~ /^(\d+)$/)
             @tag["genre_s"] = GENRES[$1.to_i]
           end
         end


### PR DESCRIPTION
See issue #50 

According to the standards on id3.org, the following conditions are allowed:

for id3v2.3 tags:  genre can be a number in brackets (e.g. "(8)") which should correspond to the old genre numbering in id3v1 (e.g. "(8)" => "Jazz")
for id3v2.4 tags:  a similar rule, except the number should not be in brackets e.g. "8" => "Jazz"
I have also seen mp3 files with id3v2.4 tags that have the number in brackets, so it makes sense to process these even if they are non-standard

The changes I have made allow the genre lookup to work in these conditions.  Please consider merging them into the next release.

Thanks
James

PS This is my first pull request, if I've done anything wrong please let me know