### PR TITLE
Cope with malformed UTF16 string tags without BOM

### DIFF
--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -1373,4 +1373,11 @@ small_vbr_mp3: !binary |
   9TZpaOWfUonFvuucxpAcYW01DAqKn1BgGgwCwLhZmv3fR/wAo2GavU78yEKA
   gSECWbr279ZwpfgF+N1rU0v/v/VFHoDnUXYgTK/NC/4Nz/8V7kiZMzIOzzAS
   h+Ix5FQdw74fuQ==
+utf16_no_bom: !binary |
+  eJzzdDFmZgACRp4QRx8nIEMdyM5WC2LIZ0hhKGLIZEgHshQYKoHYnSGRIQks
+  lsqQA2SHBDl7AzWwAjX8/2fIEOIZYgTkCoK5IUD5XCBOZihlyGMICXA1hBr9
+  /x8xRv//PSGFgQCIyMxLB1L8DAxyJxhirGcwMLNycPHyC4mIS8rIKSiramjp
+  GRibWljZOji5enj7BgSFRkTHJiSlZGTl5heVlFfV1je2tHV2902cMm3m7HkL
+  Fi1bsXrths3bduzee+DQ0ROnzp6/dOXGrbv3Hz99/urN+49fv//68/8/0D4/
+  H0dfV2M9SwM95n0wp5g0qLDW+IJYQHfIOL70JeT2wQMAPo5c1A==
 

--- a/test/test_ruby-mp3info.rb
+++ b/test/test_ruby-mp3info.rb
@@ -518,6 +518,21 @@ class Mp3InfoTest < TestCase
     end
   end
 
+  def test_utf16_no_bom
+    load_fixture_to_temp_file("utf16_no_bom")
+    Mp3Info.open(TEMP_FILE) do |mp3|
+      assert_equal "2.3.0", mp3.tag2.version
+      expected_tag = {
+        "TALB" => "\u266bRodrigo y Gabriela",
+        "TRCK"=>"1",
+        "TIT2"=>"Tamacun",
+        "TPE1"=>"Rodrigo y Gabriela"
+      }
+      tag = mp3.tag2.dup
+      assert_equal expected_tag, tag.to_hash
+    end
+  end
+
   def compute_audio_content_mp3_digest(mp3)
     pos, size = mp3.audio_content
     data = File.open(mp3.filename) do |f|


### PR DESCRIPTION
Despite the fact that ID3v2.3.0 section 3.3 and ID3v2.4 section 4 clearly
say that string format 1 requires a byte order mark, some files (e.g. many
BBC CBeebies podcasts) omit it.

Rather than treat such files as UTF16-BE and skip the first character
let's guess at UTF16-LE (which is correct for the aforementioned files and
probably quite a lot of others.)

Signed-off-by: Mike Crowe <mac@mcrowe.com>