### PR TITLE
Fix for extracting jpegs from id3v2

### DIFF
--- a/lib/mp3info/id3v2.rb
+++ b/lib/mp3info/id3v2.rb
@@ -295,13 +295,17 @@ class ID3v2 < DelegateClass(Hash)
       if header.match jpg
         mime = "jpg"
         mime_pos = header =~ jpg
-        start = Regexp.new("^\377".force_encoding("BINARY"),
-                         Regexp::FIXEDENCODING )
+        start = Regexp.new("\xFF\xD8".force_encoding("BINARY"),
+                Regexp::FIXEDENCODING )
+        start_with_anchor = Regexp.new("^\xFF\xD8".force_encoding("BINARY"),
+                            Regexp::FIXEDENCODING )
       elsif header.match png
         mime = "png"
         mime_pos = header =~ png
-        start = Regexp.new("^\x89PNG".force_encoding("BINARY"),
-                         Regexp::FIXEDENCODING )
+        start = Regexp.new("\x89PNG".force_encoding("BINARY"),
+                Regexp::FIXEDENCODING )
+        start_with_anchor = Regexp.new("^\x89PNG".force_encoding("BINARY"),
+                            Regexp::FIXEDENCODING )
       else
         mime = "dat"
       end
@@ -309,7 +313,7 @@ class ID3v2 < DelegateClass(Hash)
       puts "analysing image: #{header.inspect}..." if $DEBUG
       _, _, desc, data = pic[mime_pos, pic.length].unpack('Z*hZ*a*')
 
-      if mime != "dat" and (!data.match(start) or data.nil?)
+      if mime != "dat" and (!data.match(start_with_anchor) or data.nil?)
         real_start = pic =~ start
         data = pic[real_start, pic.length]
       end


### PR DESCRIPTION
As far as I could tell, extracting jpegs from id3v2 tags wasn't working before (at least, in some situations?).

The problem seemed to be, whenever \xFF\xD8 wasn't in the expected position after the `unpack` call, `real_start = pic =~ start ` always returned nil, since the `start` regex started with an `^`.

It seems that PNGs would have had the same issue, so I made the same change there.

In addition, expecting `\377` as the start of a jpeg didn't seem to work for my mp3s, and `\xFF\xD8` worked better (according to my google searches, jpegs do indeed always start with FF D8).