### PR TITLE
First check for pngs, before checking of jpgs

### DIFF
--- a/lib/mp3info/id3v2.rb
+++ b/lib/mp3info/id3v2.rb
@@ -292,19 +292,19 @@ class ID3v2 < DelegateClass(Hash)
       mime_pos = 0
       
       # safest way to correctly extract jpg and png is finding mime
-      if header.match jpg
-        mime = "jpg"
-        mime_pos = header =~ jpg
-        start = Regexp.new("\xFF\xD8".force_encoding("BINARY"),
-                Regexp::FIXEDENCODING )
-        start_with_anchor = Regexp.new("^\xFF\xD8".force_encoding("BINARY"),
-                            Regexp::FIXEDENCODING )
-      elsif header.match png
+      if header.match png
         mime = "png"
         mime_pos = header =~ png
         start = Regexp.new("\x89PNG".force_encoding("BINARY"),
                 Regexp::FIXEDENCODING )
         start_with_anchor = Regexp.new("^\x89PNG".force_encoding("BINARY"),
+                            Regexp::FIXEDENCODING )
+      elsif header.match jpg
+        mime = "jpg"
+        mime_pos = header =~ jpg
+        start = Regexp.new("\xFF\xD8".force_encoding("BINARY"),
+                Regexp::FIXEDENCODING )
+        start_with_anchor = Regexp.new("^\xFF\xD8".force_encoding("BINARY"),
                             Regexp::FIXEDENCODING )
       else
         mime = "dat"


### PR DESCRIPTION
I'm working on podcasting service and I need to be able to extract artwork from mp3. The gem works great most of the time. But for some mp3, like the following, it can't get the correct image.

http://www.podtrac.com/pts/redirect.mp3/audio.wnyc.org/notetoself/notetoself092315_cms532751_pod.mp3

I figured out that the issue was that when images parsed, the gem first checks for a `jpg` and then for `png`. For almost all of the troubling mp3 the fix attached in the PR. fixes this.

I made [this](https://github.com/RStankov/ruby-mp3info-test) sample project as an additional test case.