### PR TITLE
Fix COMM field parsing

### DIFF
--- a/lib/mp3info/id3v2.rb
+++ b/lib/mp3info/id3v2.rb
@@ -467,8 +467,8 @@ class ID3v2 < DelegateClass(Hash)
           p out
 =end
           comment = Mp3Info::EncodingHelper.decode_utf16(raw_tag)
-          split_val = RUBY_1_8 ? "\x00\x00" : "\x00".encode(comment.encoding)
-          out = comment.split(split_val).last rescue ""
+          split_val = RUBY_1_8 ? "\x00\x00" : "\x00".encode(comment.encoding).b
+          out = raw_tag.split(split_val).last rescue ""
         else
           comment, out = raw_tag.split("\x00", 2)
         end

--- a/lib/mp3info/id3v2.rb
+++ b/lib/mp3info/id3v2.rb
@@ -467,7 +467,7 @@ class ID3v2 < DelegateClass(Hash)
           p out
 =end
           comment = Mp3Info::EncodingHelper.decode_utf16(raw_tag)
-          split_val = RUBY_1_8 ? "\x00\x00" : "\x00".encode(comment.encoding).b
+          split_val = RUBY_1_8 ? "\x00\x00" : "\x00".encode(comment.encoding).force_encoding('ASCII-8BIT')
           out = raw_tag.split(split_val).last rescue ""
         else
           comment, out = raw_tag.split("\x00", 2)


### PR DESCRIPTION
Fix COMM field parsing when "Short content description" and "The actual text" has different byte order.